### PR TITLE
🧩 :: 카테고리별 문제 조회 API 연동

### DIFF
--- a/App/Sources/Application/AppDI.swift
+++ b/App/Sources/Application/AppDI.swift
@@ -2,15 +2,24 @@ import Foundation
 
 struct AppDI {
     let loginViewModel: LoginViewModel
+    let categoryViewModel: CategoryViewModel
+    let quizViewModel: QuizViewModel
 }
 
 extension AppDI {
     static func resolved() -> Self {
 
         let oauthService = OauthService()
+        let quizService = QuizService()
 
         let loginViewModel = LoginViewModel(oauthService: oauthService)
+        let categoryViewModel = CategoryViewModel()
+        let quizViewModel = QuizViewModel(quizService: quizService)
 
-        return .init(loginViewModel: loginViewModel)
+        return .init(
+            loginViewModel: loginViewModel,
+            categoryViewModel: categoryViewModel,
+            quizViewModel: quizViewModel
+        )
     }
 }

--- a/App/Sources/Application/Router/CategoryFlow.swift
+++ b/App/Sources/Application/Router/CategoryFlow.swift
@@ -11,6 +11,8 @@ class CategoryFlow: Flow {
         switch step {
         case .categoryRequired:
             return navigateToCategoryScreen()
+        case .quizRequired(let category):
+            return navigateToQuizScreen(category: category)
         default:
             return .none
         }
@@ -18,9 +20,22 @@ class CategoryFlow: Flow {
 
     // TODO: - categoryView 넣기
     private func navigateToCategoryScreen() -> FlowContributors {
-        let view = UIViewController()
-        view.view.backgroundColor = .white
+        let view = CategoryViewController(viewModel: container.categoryViewModel)
         presentable.pushViewController(view, animated: false)
-        return .none
+        return .one(flowContributor: .contribute(
+            withNextPresentable: view,
+            withNextStepper: view.viewModel
+        ))
+    }
+    private func navigateToQuizScreen(category: String) -> FlowContributors {
+        let quizFlow = QuizFlow()
+        
+        Flows.use(quizFlow, when: .created) { [weak self] root in
+            self?.presentable.pushViewController(root, animated: true)
+        }
+        return .one(flowContributor: .contribute(
+            withNextPresentable: quizFlow,
+            withNextStepper: OneStepper(withSingleStep: MZStep.quizRequired(category: category))
+        ))
     }
 }

--- a/App/Sources/Application/Router/CategoryFlow.swift
+++ b/App/Sources/Application/Router/CategoryFlow.swift
@@ -18,7 +18,6 @@ class CategoryFlow: Flow {
         }
     }
 
-    // TODO: - categoryView 넣기
     private func navigateToCategoryScreen() -> FlowContributors {
         let view = CategoryViewController(viewModel: container.categoryViewModel)
         presentable.pushViewController(view, animated: false)
@@ -27,6 +26,7 @@ class CategoryFlow: Flow {
             withNextStepper: view.viewModel
         ))
     }
+
     private func navigateToQuizScreen(category: String) -> FlowContributors {
         let quizFlow = QuizFlow()
         

--- a/App/Sources/Application/Router/MZStep.swift
+++ b/App/Sources/Application/Router/MZStep.swift
@@ -5,6 +5,7 @@ enum MZStep: Step {
     case tabBarRequired
     case homeRequired
     case categoryRequired
+    case quizRequired(category: String)
     case friendRequired
     case profileRequired
     case loginRequired

--- a/App/Sources/Application/Router/QuizFlow.swift
+++ b/App/Sources/Application/Router/QuizFlow.swift
@@ -1,0 +1,30 @@
+import UIKit
+import RxFlow
+
+class QuizFlow: Flow {
+    var root: Presentable { presentable }
+    private let presentable: QuizViewController
+    private let container = AppDelegate.container
+
+    init() {
+        self.presentable = QuizViewController(viewModel: container.quizViewModel)
+    }
+
+    func navigate(to step: any Step) -> FlowContributors {
+        guard let step = step as? MZStep else { return .none }
+        switch step {
+        case .quizRequired(let category):
+            return navigateToQuizScreen(category: category)
+        default:
+            return .none
+        }
+    }
+
+    private func navigateToQuizScreen(category: String) -> FlowContributors {
+        container.quizViewModel.category = category
+        return .one(flowContributor: .contribute(
+            withNextPresentable: presentable,
+            withNextStepper: presentable.viewModel
+        ))
+    }
+}

--- a/App/Sources/Scene/Category/CategoryViewController.swift
+++ b/App/Sources/Scene/Category/CategoryViewController.swift
@@ -84,5 +84,8 @@ class CategoryViewController: BaseVC<CategoryViewModel> {
                 cell.text = category.rawValue
             }
             .disposed(by: disposeBag)
+        
+        let input = CategoryViewModel.Input(index: categoryCollectionView.rx.itemSelected.asSignal())
+        let _ = viewModel.transform(input: input)
     }
 }

--- a/App/Sources/Scene/Category/CategoryViewModel.swift
+++ b/App/Sources/Scene/Category/CategoryViewModel.swift
@@ -1,18 +1,31 @@
 import Foundation
+import RxFlow
 import RxRelay
 import RxSwift
+import RxCocoa
 
-class CategoryViewModel: ViewModelType {
-    var disposeBag = DisposeBag()
-    let categories: Observable<[Categories]> = Observable.just([.VOCA, .MATH, .HISTORY, .SPORTS, .HUMOR, .SCIENCE, .SOCIETY, .MORALITY, .ETC])
+class CategoryViewModel: ViewModelType, Stepper {
+    let categories = BehaviorRelay<[Categories]>(value: [.VOCA, .MATH, .HISTORY, .SPORTS, .HUMOR, .SCIENCE, .SOCIETY, .MORALITY, .ETC])
+    var disposeBag: DisposeBag = .init()
+    var steps: PublishRelay<Step> = .init()
 
     struct Input {
+        let index: Signal<IndexPath>
     }
 
     struct Output {
     }
 
     func transform(input: Input) -> Output {
+        let quizzes = PublishRelay<Quizzes>()
+        
+        input.index.asObservable()
+            .flatMap { index -> Single<Step> in
+                Single.just(MZStep.quizRequired(category: self.categories.value[index.row].categoryName))
+            }
+            .bind(to: steps)
+            .disposed(by: disposeBag)
+        
         return Output()
     }
 }

--- a/App/Sources/Scene/Category/CategoryViewModel.swift
+++ b/App/Sources/Scene/Category/CategoryViewModel.swift
@@ -17,12 +17,8 @@ class CategoryViewModel: ViewModelType, Stepper {
     }
 
     func transform(input: Input) -> Output {
-        let quizzes = PublishRelay<Quizzes>()
-        
         input.index.asObservable()
-            .flatMap { index -> Single<Step> in
-                Single.just(MZStep.quizRequired(category: self.categories.value[index.row].categoryName))
-            }
+            .map { MZStep.quizRequired(category: self.categories.value[$0.row].categoryName) }
             .bind(to: steps)
             .disposed(by: disposeBag)
         

--- a/App/Sources/Scene/Category/Component/Categories.swift
+++ b/App/Sources/Scene/Category/Component/Categories.swift
@@ -10,4 +10,29 @@ enum Categories: String {
     case HUMOR = "유머(신조어/넌센스)"
     case SPORTS = "스포츠"
     case ETC = "기타"
+    
+    var categoryName: String {
+        get {
+            switch self {
+            case .VOCA:
+                "VOCA"
+            case .MATH:
+                "MATH"
+            case .SOCIETY:
+                "SOCIETY"
+            case .SCIENCE:
+                "SCIENCE"
+            case .HISTORY:
+                "HISTORY"
+            case .MORALITY:
+                "MORALITY"
+            case .HUMOR:
+                "HUMOR"
+            case .SPORTS:
+                "SPORTS"
+            case .ETC:
+                "ETC"
+            }
+        }
+    }
 }

--- a/App/Sources/Scene/Category/Component/CategoryCell.swift
+++ b/App/Sources/Scene/Category/Component/CategoryCell.swift
@@ -11,7 +11,7 @@ import SnapKit
 import Then
 
 class CategoryCell: UICollectionViewCell {
-    public var text: String {
+    var text: String {
         get { textLabel.text ?? "" }
         set { textLabel.text = newValue }
     }

--- a/App/Sources/Scene/Quiz/QuizViewController.swift
+++ b/App/Sources/Scene/Quiz/QuizViewController.swift
@@ -1,0 +1,29 @@
+import UIKit
+import SnapKit
+import Then
+import RxSwift
+import RxCocoa
+import RxRelay
+
+class QuizViewController: BaseVC<QuizViewModel> {
+    private let tmpView = UIView().then {
+        $0.backgroundColor = .red
+    }
+    
+    override func addView() {
+        view.addSubViews(
+            tmpView
+        )
+    }
+
+    override func setLayout() {
+        tmpView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+
+    override func bind() {
+        let input = QuizViewModel.Input()
+        let output = viewModel.transform(input: input)
+    }
+}

--- a/App/Sources/Scene/Quiz/QuizViewModel.swift
+++ b/App/Sources/Scene/Quiz/QuizViewModel.swift
@@ -18,24 +18,24 @@ class QuizViewModel: ViewModelType, Stepper {
     }
     
     struct Output {
-        var quizzes: PublishRelay<Quizzes>
+        var quizList: PublishRelay<QuizListDTO>
     }
     
     func transform(input: Input) -> Output {
-        let quizzes = PublishRelay<Quizzes>()
+        let quizList = PublishRelay<QuizListDTO>()
         
         Observable.just(category)
             .flatMap { [self] category in
-                quizService.fetchQuizzes(category)
+                quizService.fetchQuizList(category)
             }
             .subscribe(onNext: { data, res in
                 switch res {
                 case .OK:
-                    quizzes.accept(data!)
+                    quizList.accept(data!)
                 default:
                     print(res)
                 }
             }).disposed(by: disposeBag)
-        return Output(quizzes: quizzes)
+        return Output(quizList: quizList)
     }
 }

--- a/App/Sources/Scene/Quiz/QuizViewModel.swift
+++ b/App/Sources/Scene/Quiz/QuizViewModel.swift
@@ -1,0 +1,41 @@
+import Foundation
+import RxFlow
+import RxRelay
+import RxSwift
+
+class QuizViewModel: ViewModelType, Stepper {
+    var steps: PublishRelay<Step> = .init()
+    var disposeBag: DisposeBag = .init()
+    var category = ""
+    
+    private let quizService: QuizService
+    
+    init(quizService: QuizService) {
+        self.quizService = quizService
+    }
+    
+    struct Input {
+    }
+    
+    struct Output {
+        var quizzes: PublishRelay<Quizzes>
+    }
+    
+    func transform(input: Input) -> Output {
+        let quizzes = PublishRelay<Quizzes>()
+        
+        Observable.just(category)
+            .flatMap { [self] category in
+                quizService.fetchQuizzes(category)
+            }
+            .subscribe(onNext: { data, res in
+                switch res {
+                case .OK:
+                    quizzes.accept(data!)
+                default:
+                    print(res)
+                }
+            }).disposed(by: disposeBag)
+        return Output(quizzes: quizzes)
+    }
+}

--- a/App/Sources/Service/Quiz/API/QuizAPI.swift
+++ b/App/Sources/Service/Quiz/API/QuizAPI.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Moya
+
+enum QuizAPI {
+    case fetchQuizzes(_ category: String)
+}
+
+extension QuizAPI: TargetType {
+    var baseURL: URL {
+        URL(string: "https://prod-server.xquare.app/mz-sangsic")!
+    }
+    
+    var path: String {
+        switch self {
+        case .fetchQuizzes:
+            return "/quiz"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .fetchQuizzes:
+            return .get
+        }
+    }
+    
+    var task: Moya.Task {
+        switch self {
+        case .fetchQuizzes(let category):
+            return .requestParameters(
+                parameters: ["category": category],
+                encoding: URLEncoding.queryString
+            )
+        default:
+            return .requestPlain
+        }
+    }
+    
+    var headers: [String : String]? {
+        switch self {
+        case .fetchQuizzes:
+            return TokenStorage.shared.toHeader(.access)
+        }
+    }
+    
+    
+}

--- a/App/Sources/Service/Quiz/API/QuizAPI.swift
+++ b/App/Sources/Service/Quiz/API/QuizAPI.swift
@@ -2,7 +2,7 @@ import Foundation
 import Moya
 
 enum QuizAPI {
-    case fetchQuizzes(_ category: String)
+    case fetchQuizList(_ category: String)
 }
 
 extension QuizAPI: TargetType {
@@ -12,21 +12,21 @@ extension QuizAPI: TargetType {
     
     var path: String {
         switch self {
-        case .fetchQuizzes:
+        case .fetchQuizList:
             return "/quiz"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .fetchQuizzes:
+        case .fetchQuizList:
             return .get
         }
     }
     
     var task: Moya.Task {
         switch self {
-        case .fetchQuizzes(let category):
+        case .fetchQuizList(let category):
             return .requestParameters(
                 parameters: ["category": category],
                 encoding: URLEncoding.queryString
@@ -38,7 +38,7 @@ extension QuizAPI: TargetType {
     
     var headers: [String : String]? {
         switch self {
-        case .fetchQuizzes:
+        case .fetchQuizList:
             return TokenStorage.shared.toHeader(.access)
         }
     }

--- a/App/Sources/Service/Quiz/Entity/QuizzesEntity.swift
+++ b/App/Sources/Service/Quiz/Entity/QuizzesEntity.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct QuizListEntity {
+    let quizList: [QuizEntity]
+
+    init(quizList: [QuizEntity]) {
+        self.quizList = quizList
+    }
+}
+
+struct QuizEntity {
+    let id: Int
+    let content: String
+
+    init(id: Int, content: String) {
+        self.id = id
+        self.content = content
+    }
+}

--- a/App/Sources/Service/Quiz/QuizService.swift
+++ b/App/Sources/Service/Quiz/QuizService.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Moya
+import RxMoya
+import RxSwift
+import RxCocoa
+
+class QuizService {
+    private let provider = MoyaProvider<QuizAPI>(plugins: [MoyaLoggingPlugin()])
+    
+    func fetchQuizzes(_ category: String) -> Single<(Quizzes?, NetworkingResult)> {
+        return provider.rx.request(.fetchQuizzes(category))
+            .filterSuccessfulStatusCodes()
+            .map(Quizzes.self)
+            .map { return ($0, .OK) }
+            .catch { error in
+                print(error)
+                return .just((nil, .DEFAULT))
+            }
+    }
+}

--- a/App/Sources/Service/Quiz/QuizService.swift
+++ b/App/Sources/Service/Quiz/QuizService.swift
@@ -7,10 +7,10 @@ import RxCocoa
 class QuizService {
     private let provider = MoyaProvider<QuizAPI>(plugins: [MoyaLoggingPlugin()])
     
-    func fetchQuizzes(_ category: String) -> Single<(Quizzes?, NetworkingResult)> {
-        return provider.rx.request(.fetchQuizzes(category))
+    func fetchQuizList(_ category: String) -> Single<(QuizListDTO?, NetworkingResult)> {
+        return provider.rx.request(.fetchQuizList(category))
             .filterSuccessfulStatusCodes()
-            .map(Quizzes.self)
+            .map(QuizListDTO.self)
             .map { return ($0, .OK) }
             .catch { error in
                 print(error)

--- a/App/Sources/Service/Quiz/Response/Quizzes.swift
+++ b/App/Sources/Service/Quiz/Response/Quizzes.swift
@@ -1,15 +1,27 @@
 import Foundation
 
-struct Quizzes: Decodable {
-    let quiz: [Quizz]
+struct QuizListDTO: Decodable {
+    let quiz: [QuizDTO]
 }
 
-struct Quizz: Decodable {
+struct QuizDTO: Decodable {
     let id: Int
     let content: String
     
     enum CodingKeys: String, CodingKey {
         case id = "quiz_id"
         case content
+    }
+}
+
+extension QuizListDTO {
+    func toDomain() -> QuizListEntity {
+        return .init(quizList: quiz.map { $0.toDomain() })
+    }
+}
+
+extension QuizDTO {
+    func toDomain() -> QuizEntity {
+        return .init(id: id, content: content)
     }
 }

--- a/App/Sources/Service/Quiz/Response/Quizzes.swift
+++ b/App/Sources/Service/Quiz/Response/Quizzes.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct Quizzes: Decodable {
+    let quiz: [Quizz]
+}
+
+struct Quizz: Decodable {
+    let id: Int
+    let content: String
+    
+    enum CodingKeys: String, CodingKey {
+        case id = "quiz_id"
+        case content
+    }
+}

--- a/App/Sources/Service/Util/NetworkingResult.swift
+++ b/App/Sources/Service/Util/NetworkingResult.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+enum NetworkingResult: Int {
+    case OK = 200
+    case CREATED = 201
+    case NOCONTENT = 204
+    case BADREQUEST = 400
+    case UNAUTHORIZED = 401
+    case NOTFOUND = 404
+    case INTERNALSERVERERROR = 500
+    case DEFAULT = 0
+}

--- a/App/Sources/Service/Util/TokenStorage.swift
+++ b/App/Sources/Service/Util/TokenStorage.swift
@@ -33,6 +33,24 @@ class TokenStorage {
             keyChain.set(newValue, forKey: TokenType.refresh.key)
         }
     }
+    
+    func toHeader(_ tokenType: TokenType) -> [String: String] {
+        guard let accessToken = self.accessToken,
+              let refreshToken = self.refreshToken
+        else {
+            return ["Content-type": "application/json"]
+        }
+        
+        switch tokenType {
+        case .access:
+            return [
+                "Content-type": "application/json",
+                "Authorization": accessToken
+            ]
+        default:
+            return ["Content-type": "application/json"]
+        }
+    }
 
     func removeToken() {
         accessToken = nil


### PR DESCRIPTION
## 개요
>  카테고리별 문제 조회 API를 연동합니다.

## 작업사항
- 카테고리별 문제 분류 화면에서 셀을 클릭할 시 각 카테고리별 문제 풀이 화면으로 이동하고, 문제를 조회합니다.

## 변경로직
- 카테고리(메인) 화면에서 셀 클릭 ➡️ QuizViewModel에 category(string) 전달 ➡️ 문제 조회 API 호출
- quizRequired Step 추가
- CategoryFlow: navigateToQuizScreen() ➡️ QuizFlow (root presentable == QuizViewController)

## UI
<img src="https://github.com/DSM-SOGONG-MZ-SANGSIC/MZ-iOS/assets/101160430/f922cea4-082e-4fde-93ce-63bfc7e027bd" width="300px"></img>



